### PR TITLE
Add custom catalog store

### DIFF
--- a/src/components/react/catalogo/CatalogoSection.tsx
+++ b/src/components/react/catalogo/CatalogoSection.tsx
@@ -11,6 +11,7 @@ import { Card } from "@heroui/react";
 import { ReorderModal } from "./ReorderModal";
 
 import { useCatalogStore } from "./store/useCatalogStore";
+import { useCustomCatalogStore } from "./store/customCatalogStore";
 import { useLoadCatalog } from "./hooks/useLoadCatalog";
 import { useState } from "react";
 import { ALL_VERSIONS, useVersionStore } from "./store/useVersionStore";
@@ -18,6 +19,7 @@ import { PikIcon } from "./V2/PickIcon";
 
 export const CatalogoSection = ({ currentLocale }: { currentLocale: string }) => {
   const { selectedProducts, showPrices, coverUrl, loading, toggleProduct } = useCatalogStore();
+  const { customSections, toggleProduct: toggleCustomProduct } = useCustomCatalogStore();
   const { currentVersion, updateVersion } = useVersionStore();
   const { tCat } = useLoadCatalog(currentLocale);
   const [showModal, setShowModal] = useState(false);
@@ -75,63 +77,83 @@ export const CatalogoSection = ({ currentLocale }: { currentLocale: string }) =>
 
           {
             currentVersion.id === ALL_VERSIONS.V1.id && <>
-              {Object.entries(selectedProducts).map(([key, cat]) => (
-                <CategorySectionV1
-                  key={key}
-                  categoryKey={key}
-                  categoryName={cat.categoryName}
-                  categoryDescription={cat.categoryDescription}
-                  products={cat.products}
-                  t_catalog={tCat}
-                  showPrices={showPrices}
-                  onToggle={(code) => toggleProduct(key, code)}
-                />
+              {Object.entries({ ...selectedProducts, ...customSections })
+                .filter(([, cat]) => !cat.hidden)
+                .map(([key, cat]) => (
+                  <CategorySectionV1
+                    key={key}
+                    categoryKey={key}
+                    categoryName={cat.categoryName}
+                    categoryDescription={cat.categoryDescription}
+                    products={cat.products}
+                    t_catalog={tCat}
+                    showPrices={showPrices}
+                    onToggle={(code) =>
+                      selectedProducts[key]
+                        ? toggleProduct(key, code)
+                        : toggleCustomProduct(key, code)
+                    }
+                  />
               ))}
             </>
           }
 
           {
             currentVersion.id === ALL_VERSIONS.V2.id && <>
-              {Object.entries(selectedProducts).map(([key, cat]) => (
-                <CategorySectionV2
-                  key={key}
-                  categoryKey={key}
-                  categoryName={cat.categoryName}
-                  categoryDescription={cat.categoryDescription}
-                  products={cat.products}
-                  t_catalog={tCat}
-                  showPrices={showPrices}
-                  onToggle={(code) => toggleProduct(key, code)}
-                />
+              {Object.entries({ ...selectedProducts, ...customSections })
+                .filter(([, cat]) => !cat.hidden)
+                .map(([key, cat]) => (
+                  <CategorySectionV2
+                    key={key}
+                    categoryKey={key}
+                    categoryName={cat.categoryName}
+                    categoryDescription={cat.categoryDescription}
+                    products={cat.products}
+                    t_catalog={tCat}
+                    showPrices={showPrices}
+                    onToggle={(code) =>
+                      selectedProducts[key]
+                        ? toggleProduct(key, code)
+                        : toggleCustomProduct(key, code)
+                    }
+                  />
               ))}
             </>
           }
 
           {
             currentVersion.id === ALL_VERSIONS.V2_2.id && <>
-              {Object.entries(selectedProducts).map(([key, cat]) => (
-                <CategorySectionV2_2
-                  key={key}
-                  categoryKey={key}
-                  categoryName={cat.categoryName}
-                  categoryDescription={cat.categoryDescription}
-                  products={cat.products}
-                  t_catalog={tCat}
-                  showPrices={showPrices}
-                  onToggle={(code) => toggleProduct(key, code)}
-                />
+              {Object.entries({ ...selectedProducts, ...customSections })
+                .filter(([, cat]) => !cat.hidden)
+                .map(([key, cat]) => (
+                  <CategorySectionV2_2
+                    key={key}
+                    categoryKey={key}
+                    categoryName={cat.categoryName}
+                    categoryDescription={cat.categoryDescription}
+                    products={cat.products}
+                    t_catalog={tCat}
+                    showPrices={showPrices}
+                    onToggle={(code) =>
+                      selectedProducts[key]
+                        ? toggleProduct(key, code)
+                        : toggleCustomProduct(key, code)
+                    }
+                  />
               ))}
             </>
           }
 
                     {
             currentVersion.id === ALL_VERSIONS.V3.id && <>
-              {Object.entries(selectedProducts).map(([key, cat]) => (
-                <CategorySectionV3
-                  key={key}
-                  categoryKey={key}
-                  products={cat.products}
-                />
+              {Object.entries({ ...selectedProducts, ...customSections })
+                .filter(([, cat]) => !cat.hidden)
+                .map(([key, cat]) => (
+                  <CategorySectionV3
+                    key={key}
+                    categoryKey={key}
+                    products={cat.products}
+                  />
               ))}
             </>
           }

--- a/src/components/react/catalogo/store/customCatalogStore.ts
+++ b/src/components/react/catalogo/store/customCatalogStore.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { GroupedByCategory, ProductData } from "../types";
+
+interface CustomCategory extends GroupedByCategory[string] {
+  hidden?: boolean;
+}
+
+interface CustomCatalogState {
+  customSections: Record<string, CustomCategory>;
+}
+
+interface CustomCatalogActions {
+  addSection: (key: string, data: CustomCategory) => void;
+  updateSection: (key: string, data: CustomCategory) => void;
+  removeSection: (key: string) => void;
+  toggleProduct: (category: string, code: string) => void;
+  toggleVisibility: (category: string) => void;
+}
+
+export const useCustomCatalogStore = create<CustomCatalogState & CustomCatalogActions>(
+  persist(
+    (set, get) => ({
+      customSections: {},
+      addSection: (key, data) =>
+        set({ customSections: { ...get().customSections, [key]: data } }),
+      updateSection: (key, data) =>
+        set({ customSections: { ...get().customSections, [key]: data } }),
+      removeSection: (key) => {
+        const next = { ...get().customSections };
+        delete next[key];
+        set({ customSections: next });
+      },
+      toggleProduct: (category, code) => {
+        const next = { ...get().customSections };
+        const product = next[category]?.products.find((p: ProductData) => p.code === code);
+        if (product) product.show = !product.show;
+        set({ customSections: next });
+      },
+      toggleVisibility: (category) => {
+        const next = { ...get().customSections };
+        if (next[category]) {
+          next[category].hidden = !next[category].hidden;
+          set({ customSections: next });
+        }
+      },
+    }),
+    { name: "custom-catalog" }
+  )
+);


### PR DESCRIPTION
## Summary
- enable local storage backed custom catalog sections
- show custom sections alongside normal catalog data

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-astro')*

------
https://chatgpt.com/codex/tasks/task_e_68778ac97ab0832d81ebda74b6b1b716